### PR TITLE
Changed way of getting appi and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,7 @@ Run the command to create a folder in the current working directory for each "se
 
 These `.json` files can then be parsed by Steam Rom Manager to import them in to Steam with the correct artwork.
 
-The manifest files make use of the [Lutris CLI protocol link](https://github.com/lutris/lutris#command-line-options) functionality, using `lutris:` followed by the service and a game identifier, which will open a game via Lutris if it is installed, or install it if not.
-
-Unfortuantely this doesn't work for all services currently, see the serivce compatibility table below. Hoping to get a PR in to Lutris to make this work universally.
-
-| Service | Working |
-| --------- | ----------- |
-| egs      | :heavy_check_mark: |
-| ea_play      | :heavy_check_mark: |
-| gog      | :heavy_check_mark: |
-| amazon      | :heavy_check_mark: |
-| ubisoft      | Partial Compatibility |
+The manifest files make use of the [Lutris CLI protocol link](https://github.com/lutris/lutris#command-line-options) functionality, using `lutris:` followed by the service and a game identifier, which will open a game via Lutris if it is installed, or install it if not. Games will have to be uninstalled via Lutris directly.
 
 ## Installation
 

--- a/lutris-import.sh
+++ b/lutris-import.sh
@@ -79,16 +79,7 @@ for service in $(echo $services | jq -cr '.[]'); do
     echo "[" >> ./$service/$service-manifest.json
     echo "$games" | jq -cr ".[] | select(.service == \"$service\")" | while read -r game; do
         game_name=$(echo $game | jq -r '.name')
-        game_details=$(echo $game | jq -r '.details')
-        if [[ $service == "egs" ]]; then
-          app_id=$(echo $game_details | jq -r '.appName')
-        elif [[ $service == "ea_app" ]]; then
-          app_id=$(echo $game_details | jq -r '.contentId')
-        elif [[ $service == "ubisoft" ]]; then
-          app_id=$(echo $game_details | jq -r '.spaceId')
-        else
-          app_id=$(echo $game_details | jq -r '.id')
-        fi
+        app_id=$(echo $game | jq -r '.appid')
         logit "Adding game $game_name to manifest file \"$service-manifest.json\"" grn
         echo "  {" >> ./$service/$service-manifest.json
         echo "    \"title\": \"$game_name\"," >> ./$service/$service-manifest.json


### PR DESCRIPTION
Changed method for acquiring the game identifier (appid) as it is now output directly by the Lutris CLI command and so is standard between sources.

Updated readme.